### PR TITLE
fix: added dns to scripts and addressed pnpm version issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `.contract` file combines the Wasm and metadata into one file and can be use
 
 ## Running front end dApp examples
 
-1. Install [nodejs](https://nodejs.org/en/) and then install [pnpm](https://pnpm.io/) `npm install -g pnpm`
+1. Install [nodejs](https://nodejs.org/en/) and then install [pnpm](https://pnpm.io/) `npm install -g pnpm@8.4.0`
 2. Install dependencies `pnpm i`
 3. Run each example with `pnpm <contract-example-name>`. e.g. `pnpm flipper`
 4. Visit [http://localhost:5173](http://localhost:5173) in your browser.
@@ -42,6 +42,7 @@ The `.contract` file combines the Wasm and metadata into one file and can be use
 * `pnpm basic-contract-caller`
 * `pnpm contract-terminate`
 * `pnpm contract-transfer`
+* `pnpm dns`
 * `pnpm erc20`
 * `pnpm erc721`
 * `pnpm flipper`

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "basic-contract-caller": "pnpm --filter basic-contract-caller dev",
     "contract-terminate": "pnpm --filter contract-terminate dev",
     "contract-transfer": "pnpm --filter contract-transfer dev",
+    "dns": "pnpm --filter dns-frontend-example dev",
     "erc20": "pnpm --filter erc20 dev",
     "erc721": "pnpm --filter erc721 dev",
     "incrementer": "pnpm --filter incrementer dev"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "ui"
   - "basic-contract-caller/frontend"
   - "contract-transfer/frontend"
+  - "dns/frontend"
   - "contract-terminate/frontend"
   - "erc20/frontend"
   - "erc721/frontend"


### PR DESCRIPTION
## Description:
  - Updated local build instructions.
  - Updated `npm` scripts to include the available `dns` frontend.

## Reasons:
  - Using `npm install -g pnpm` will install the latest version which keeps giving incompatibility error during builds.
  - `dns` frontend was available but not included among `npm` build scripts.