### PR TITLE
chore: remove relative deps & minor fixes

### DIFF
--- a/basic-contract-caller/Cargo.toml
+++ b/basic-contract-caller/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "basic-contract-caller"
-version = "5.1.0"
+version = "6.0.0"
 authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.1.0", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 # Note: We **need** to specify the `ink-as-dependency` feature.
 #
@@ -14,7 +14,7 @@ ink = { version = "5.1.0", default-features = false }
 other-contract = { path = "other-contract", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.1.0" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/basic-contract-caller/lib.rs
+++ b/basic-contract-caller/lib.rs
@@ -7,6 +7,7 @@ mod basic_contract_caller {
     /// Note that the other contract must have re-exported it (`pub use
     /// OtherContractRef`) for us to have access to it.
     use other_contract::OtherContractRef;
+    use ink::{H256, U256};
 
     #[ink(storage)]
     pub struct BasicContractCaller {
@@ -19,11 +20,11 @@ mod basic_contract_caller {
         ///
         /// To do this we will use the uploaded `code_hash` of `OtherContract`.
         #[ink(constructor)]
-        pub fn new(other_contract_code_hash: Hash) -> Self {
+        pub fn new(other_contract_code_hash: H256) -> Self {
             let other_contract = OtherContractRef::new(true)
                 .code_hash(other_contract_code_hash)
-                .endowment(0)
-                .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
+                .endowment(U256::from(0))
+                .salt_bytes(Some([1;32]))
                 .instantiate();
 
             Self { other_contract }

--- a/basic-contract-caller/other-contract/Cargo.toml
+++ b/basic-contract-caller/other-contract/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "other-contract"
-version = "5.1.0"
+version = "6.0.0"
 authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.1.0", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.1.0" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/call-runtime/Cargo.toml
+++ b/call-runtime/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false }
 
 # We need to explicitly turn off some of the `sp-io` features, to avoid conflicts
@@ -18,7 +18,7 @@ sp-io = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01e
 sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false, features = ["disable_target_static_assertions"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/combined-extension/Cargo.toml
+++ b/combined-extension/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 psp22_extension = { path = "../psp22-extension", default-features = false, features = ["ink-as-dependency"] }
 rand_extension = { path = "../rand-extension", default-features = false, features = ["ink-as-dependency"] }
 

--- a/conditional-compilation/Cargo.toml
+++ b/conditional-compilation/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/contract-storage/Cargo.toml
+++ b/contract-storage/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/contract-terminate/Cargo.toml
+++ b/contract-terminate/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/contract-transfer/Cargo.toml
+++ b/contract-transfer/Cargo.toml
@@ -6,11 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-#ink_e2e = { path = "../../../crates/e2e" }
-ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["sandbox"] }
 
 [lib]
 path = "lib.rs"

--- a/contract-xcm/Cargo.toml
+++ b/contract-xcm/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["sandbox"] }
 
 [lib]
 path = "lib.rs"

--- a/cross-contract-calls/Cargo.toml
+++ b/cross-contract-calls/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 # Note: We **need** to specify the `ink-as-dependency` feature.
 #
@@ -15,7 +15,7 @@ other-contract = { path = "other-contract", default-features = false, features =
 pallet-revive-uapi = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/cross-contract-calls/other-contract/Cargo.toml
+++ b/cross-contract-calls/other-contract/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 pallet-revive-uapi = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/custom-allocator/Cargo.toml
+++ b/custom-allocator/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 # We're going to use a different allocator than the one provided by ink!. To do that we
 # first need to disable the included memory allocator.
-ink = { path = "../../../crates/ink", default-features = false, features = ["no-allocator"]  }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 # todo
 #foo = { path = "../../../foo", default-features = false }
@@ -17,7 +17,7 @@ ink = { path = "../../../crates/ink", default-features = false, features = ["no-
 #bumpalo = "3.16.0"
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/custom-environment/Cargo.toml
+++ b/custom-environment/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/dns/Cargo.toml
+++ b/dns/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/e2e-call-runtime/Cargo.toml
+++ b/e2e-call-runtime/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/e2e-runtime-only-backend/Cargo.toml
+++ b/e2e-runtime-only-backend/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.1.0", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.1.0" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/e2e-runtime-only-backend/lib.rs
+++ b/e2e-runtime-only-backend/lib.rs
@@ -2,6 +2,8 @@
 
 #[ink::contract]
 pub mod flipper {
+    use ink::U256;
+
     #[ink(storage)]
     pub struct Flipper {
         value: bool,
@@ -34,7 +36,7 @@ pub mod flipper {
 
         /// Returns the current balance of the Flipper.
         #[ink(message)]
-        pub fn get_contract_balance(&self) -> Balance {
+        pub fn get_contract_balance(&self) -> U256 {
             self.env().balance()
         }
     }

--- a/erc1155/Cargo.toml
+++ b/erc1155/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/erc20/Cargo.toml
+++ b/erc20/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/erc721/Cargo.toml
+++ b/erc721/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 event-def = { path = "event-def", default-features = false }
 event-def2 = { path = "event-def2", default-features = false }
 event-def-unused = { path = "event-def-unused", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/events/event-def-unused/Cargo.toml
+++ b/events/event-def-unused/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }  
 
 [lib]
 path = "src/lib.rs"

--- a/events/event-def/Cargo.toml
+++ b/events/event-def/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "src/lib.rs"

--- a/events/event-def2/Cargo.toml
+++ b/events/event-def2/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "src/lib.rs"

--- a/flipper/Cargo.toml
+++ b/flipper/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["sandbox"] }
 hex = { version = "0.4.3" }
 
 [lib]

--- a/incrementer/Cargo.toml
+++ b/incrementer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/lazyvec/Cargo.toml
+++ b/lazyvec/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/mapping/Cargo.toml
+++ b/mapping/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.1.0", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.1.0" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/mapping/lib.rs
+++ b/mapping/lib.rs
@@ -5,6 +5,7 @@
 #[ink::contract]
 mod mapping {
     use ink::{
+        H160,
         prelude::{
             string::String,
             vec::Vec,
@@ -23,9 +24,9 @@ mod mapping {
     #[derive(Default)]
     pub struct Mappings {
         /// Mapping from owner to number of owned token.
-        balances: Mapping<AccountId, Balance>,
+        balances: Mapping<H160, Balance>,
         /// Mapping from owner to aliases.
-        names: Mapping<AccountId, Vec<String>>,
+        names: Mapping<H160, Vec<String>>,
     }
 
     impl Mappings {

--- a/multi-contract-caller/Cargo.toml
+++ b/multi-contract-caller/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 adder = { path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { path = "subber", default-features = false, features = ["ink-as-dependency"] }
 accumulator = { path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/multi-contract-caller/accumulator/Cargo.toml
+++ b/multi-contract-caller/accumulator/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/multi-contract-caller/adder/Cargo.toml
+++ b/multi-contract-caller/adder/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 

--- a/multi-contract-caller/subber/Cargo.toml
+++ b/multi-contract-caller/subber/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 

--- a/multisig/Cargo.toml
+++ b/multisig/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/payment-channel/Cargo.toml
+++ b/payment-channel/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false }
 
 [dev-dependencies]

--- a/psp22-extension/Cargo.toml
+++ b/psp22-extension/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/rand-extension/Cargo.toml
+++ b/rand-extension/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/runtime-call-contract/Cargo.toml
+++ b/runtime-call-contract/Cargo.toml
@@ -28,11 +28,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 flipper-traits = { path = "traits", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e", features = ["sandbox"] }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["sandbox"] }
 sandbox-runtime = { path = "sandbox-runtime", default-features = false }
 scale-value = "0.18.0"
 # can't use workspace dependency because of `cargo-contract` build not

--- a/static-buffer/Cargo.toml
+++ b/static-buffer/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.1.0", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.1.0" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/static-buffer/lib.rs
+++ b/static-buffer/lib.rs
@@ -2,9 +2,12 @@
 
 #[ink::contract]
 pub mod static_buffer {
-    use ink::prelude::{
-        string::String,
-        vec::Vec,
+    use ink::{
+        H160,
+        prelude::{
+            string::String,
+            vec::Vec,
+        }
     };
 
     #[allow(unused_imports)]
@@ -30,7 +33,7 @@ pub mod static_buffer {
         /// Returns the caller of the contract.
         /// Should panic if the buffer size is less than 32 bytes.
         #[ink(message)]
-        pub fn get_caller(&self) -> AccountId {
+        pub fn get_caller(&self) -> H160 {
             self.env().caller()
         }
 

--- a/trait-dyn-cross-contract-calls/Cargo.toml
+++ b/trait-dyn-cross-contract-calls/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 dyn-traits = { path = "./traits", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 trait-incrementer = { path = "./contracts/incrementer", default-features = false, features = ["ink-as-dependency"] }
 
 [lib]

--- a/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
+++ b/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 dyn-traits = { path = "../../traits", default-features = false }
 

--- a/trait-dyn-cross-contract-calls/traits/Cargo.toml
+++ b/trait-dyn-cross-contract-calls/traits/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/trait-erc20/Cargo.toml
+++ b/trait-erc20/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/trait-flipper/Cargo.toml
+++ b/trait-flipper/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/trait-incrementer/Cargo.toml
+++ b/trait-incrementer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 traits = { path = "./traits", default-features = false }
 

--- a/trait-incrementer/traits/Cargo.toml
+++ b/trait-incrementer/traits/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/delegator/Cargo.toml
+++ b/upgradeable-contracts/delegator/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 delegatee = { path = "delegatee", default-features = false, features = ["ink-as-dependency"] }
 delegatee2 = { path = "delegatee2", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/delegator/delegatee/Cargo.toml
+++ b/upgradeable-contracts/delegator/delegatee/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/delegator/delegatee2/Cargo.toml
+++ b/upgradeable-contracts/delegator/delegatee2/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/set-code-hash-migration/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash-migration/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 migration = { path = "./migration", default-features = false, features = ["ink-as-dependency"] }
 updated-incrementer = { path = "./updated-incrementer", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/set-code-hash-migration/migration/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash-migration/migration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/set-code-hash-migration/updated-incrementer/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash-migration/updated-incrementer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 updated-incrementer = { path = "updated-incrementer", default-features = false, features = ["ink-as-dependency"] }
 
 [lib]

--- a/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [lib]
 path = "lib.rs"

--- a/vesting/Cargo.toml
+++ b/vesting/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Use Ink <ink@use.ink>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.1.0", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
 

--- a/wildcard-selector/Cargo.toml
+++ b/wildcard-selector/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../crates/ink", default-features = false }
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/workspace-contracts/Cargo.toml
+++ b/workspace-contracts/Cargo.toml
@@ -4,5 +4,5 @@ exclude = [".cargo", "target"]
 resolver = "2"
 
 [workspace.dependencies]
-ink = { version = "5.1.0", default-features = false }
-ink_e2e = "5.1.0"
+ink = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
+ink_e2e = { git = "https://github.com/use-ink/ink.git", branch = "master", version = "6.0.0-alpha", default-features = false }


### PR DESCRIPTION
Fixes some of the ink! dependencies using relative paths and introduces some minor changes for certain contracts to have them build.